### PR TITLE
Add NATs, burstable, and sunsetting to vocab

### DIFF
--- a/styles/DigitalOcean/SpellingSuggestions.yml
+++ b/styles/DigitalOcean/SpellingSuggestions.yml
@@ -30,3 +30,4 @@ swap:
     uncompress:                 decompress
     pulldown:                   pull-down
     an URL:                     a URL
+    sunset(?:|s|ed|ing)?:       deprecate(s)

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -163,7 +163,7 @@ MongoDB
 multiset[s]?
 MySQL
 Namecheap
-NAT[s]
+NAT(|s)
 netfilter
 Netplan
 [Nn]amespace

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -244,6 +244,7 @@ ssh-copy-id
 [Ss]ubnet(|s|work|works)
 Streamlit
 sudo
+sunset[t](|s|ed)
 Supabase
 SVG
 syslog

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -243,7 +243,7 @@ ssh-copy-id
 [Ss]ubnet(|s|work|works)
 Streamlit
 sudo
-sunset[t](|s|ed)
+sunset(|s|ted|ting)
 Supabase
 SVG
 syslog

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -67,7 +67,6 @@ data's
 Deepspeed
 DigiCert
 Dockerfile[s]?
-[Dd]ockerhub
 dockershim
 [Ee]gress(|es|ed|ing)
 Enom

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -26,6 +26,7 @@ balancer's
 Bluehost
 Boto
 Btrfs
+[Bb]urstable
 byobu
 CA[s]?
 CCM(?:|s|'s)
@@ -66,6 +67,7 @@ data's
 Deepspeed
 DigiCert
 Dockerfile[s]?
+[Dd]ockerhub
 dockershim
 [Ee]gress(|es|ed|ing)
 Enom
@@ -162,6 +164,7 @@ MongoDB
 multiset[s]?
 MySQL
 Namecheap
+NAT[s]
 netfilter
 Netplan
 [Nn]amespace

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -163,7 +163,7 @@ MongoDB
 multiset[s]?
 MySQL
 Namecheap
-NAT(|s)
+NAT[s]?
 netfilter
 Netplan
 [Nn]amespace

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -243,7 +243,6 @@ ssh-copy-id
 [Ss]ubnet(|s|work|works)
 Streamlit
 sudo
-sunset(|s|ted|ting)
 Supabase
 SVG
 syslog


### PR DESCRIPTION
**Objective**: Adding new vocabulary to `styles/config/vocabularies/Technical/accept.txt`

**Purpose:** I'm adding the new vocabulary as Vale doesn't recognize them in separate PRs I have 

The new vocabulary I added: 
- NAT / NATs -> NAT[s]
- burstable -> [Bb]urstable
- sunset / sunsets / sunsetting / sunsetted -> sunset[|s|ted|ting]

_Tested_

