### PR TITLE
Adding Makefile to Accepted Vocabulary

### DIFF
--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -156,6 +156,7 @@ Logstash
 Logtail
 logtalez
 Lua
+[Mm]akefiles?
 matplotlib
 M[Bb]ps
 Megaport


### PR DESCRIPTION
I added Makefile to Vale's technical accepted vocabulary list since it is a technical term that I think we should acknowledge. 

Here is how I added the term to the list: `[Mm]akefiles?`.

