### PR TITLE
Add PDocs phrasing rule, and enforce 'menu' over 'navigation'

### DIFF
--- a/styles/PDocs/PhrasingSuggestions.yml
+++ b/styles/PDocs/PhrasingSuggestions.yml
@@ -5,4 +5,4 @@ level: error
 action:
     name: replace
 swap:
-    navigation:     menu
+    navigation: menu

--- a/styles/PDocs/PhrasingSuggestions.yml
+++ b/styles/PDocs/PhrasingSuggestions.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+ignorecase: true
+level: error
+action:
+    name: replace
+swap:
+    navigation:     menu


### PR DESCRIPTION
We have suggestions rules at the DO style level, but this PR creates one for PDocs-specific wording.