### PR TITLE
Add hyperparameter to vocab

### DIFF
--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -115,6 +115,7 @@ Hetzner
 HPA[s]?
 (HTTP|http)
 (HTTPS|https)
+[Hh]yperparameters?
 Icinga
 [Ii]dempotence
 [Ii]mpactful


### PR DESCRIPTION
The regex pattern added to `accept.txt`: `[Hh]yperparameters?` as this term can be: 
* Capitalized
* Lowercased
* Singular
* Plural