### PR TITLE
Fix syntax in PDocs brevity rule

### DIFF
--- a/styles/PDocs/Brevity.yml
+++ b/styles/PDocs/Brevity.yml
@@ -10,4 +10,4 @@ tokens:
     - as a note
     - you can see that
     - as you can see
-    - be sure (?to|that)
+    - be sure (?:to|that)


### PR DESCRIPTION
Missing a colon.