### PR TITLE
Add PyDo rules

### DIFF
--- a/styles/DigitalOcean/DigitalOceanTerms.yml
+++ b/styles/DigitalOcean/DigitalOceanTerms.yml
@@ -21,3 +21,7 @@ swap:
     'Digitalocean':                     DigitalOcean
     'digitalocean^(?:.com)':            DigitalOcean
     droplet[s]?:                        Droplet(s)
+    pydo:                               pydo (code formatting)
+    '[Pp][Yy][Dd]O':                    PyDo
+    '[Pp]Y[Dd][Oo]':                    PyDo
+    (?:Pydo|pyDo):                      PyDo

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -215,7 +215,6 @@ Prisma
 psql
 Punycode
 PVC
-pydo
 qcow
 Rackspace
 Razer

--- a/styles/ignore/words-with-suggestions.txt
+++ b/styles/ignore/words-with-suggestions.txt
@@ -26,6 +26,7 @@ nginx's
 pageview
 pageviews
 pulldown
+pydo
 ratelimit
 ratelimited
 ratelimiting


### PR DESCRIPTION
Enforce "PyDo" except when referring to the package `pydo`.