### PR TITLE
feat: add PDocs.WeakOpeners rule

### DIFF
--- a/styles/PDocs/WeakOpeners.yml
+++ b/styles/PDocs/WeakOpeners.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "Avoid phrases that describe the document rather than its subject: '%s'."
+link: https://docs.digitalocean.com/style/pdocs/llm-friendly-content/
+ignorecase: true
+level: warning
+tokens:
+    - in this guide
+    - in this article
+    - in this tutorial
+    - in this document
+    - this (?:article|guide|tutorial|page|document) (?:explains|covers|describes|shows|walks)
+    - we(?:'ll| will) walk you through
+    - you(?:'ll| will) learn (?:how to|about)
+    - learn (?:more about|how to)


### PR DESCRIPTION
## Summary

Adds `PDocs.WeakOpeners`, a warning-level Vale rule that flags self-referential phrases like "In this guide...", "This article explains...", and "You'll learn how to...". These patterns describe the document rather than its subject and weaken descriptions and introductions, particularly for LLM retrieval.

Companion to [product-docs#5848](https://github.com/digitalocean/product-docs/pull/5848), which adds LLM-friendly content guidance and references this rule.

Set to `warning` so it does not fail CI checks. Can be promoted to `error` after the existing content is cleaned up.

[PDOCS-3754](https://do-internal.atlassian.net/browse/PDOCS-3754)

## Test plan

- [ ] Run `vale sync && vale content/products/` locally in product-docs after this merges and a new release is cut
- [ ] Verify the rule flags known weak openers without excessive false positives
- [ ] Confirm CI checks still pass (warning level should not block)

[PDOCS-3754]: https://do-internal.atlassian.net/browse/PDOCS-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ