### PR TITLE
Add vocabulary for platform docs Vale cleanup

### DIFF
--- a/styles/config/vocabularies/TechProperNouns/accept.txt
+++ b/styles/config/vocabularies/TechProperNouns/accept.txt
@@ -121,3 +121,6 @@ Vultr
 Wikidata
 WordPress
 Xeon
+authentik
+Keycloak
+Kotak

--- a/styles/config/vocabularies/Technical/accept.txt
+++ b/styles/config/vocabularies/Technical/accept.txt
@@ -241,3 +241,12 @@ xrdp
 YAML
 Zombieload
 [Zz]sh
+[Cc]rypto
+[Ss]tablecoins?
+LLMs?
+[Ss]ubprocessors?
+[Dd]DoS
+[Aa]utoscalers?
+prepopulated
+[Mm]ultivalued
+substring


### PR DESCRIPTION
## Summary

- Add Technical vocabulary entries for crypto, stablecoins, LLMs, subprocessors, DDoS, autoscaler, and related platform terms.
- Add TechProperNouns entries for authentik, Keycloak, and Kotak.

Supports product-docs `content/platform/` Vale cleanup (front matter slug/alias ignores stay in that repo).

## Test plan

- [ ] `vale sync` and lint a sample of platform docs after release