### PR TITLE
fix: skip decimals in NumberCommas unit patterns

### DIFF
--- a/styles/DigitalOcean/NumberCommas.yml
+++ b/styles/DigitalOcean/NumberCommas.yml
@@ -4,9 +4,10 @@ link: https://docs.digitalocean.com/style/digitalocean/grammar/numbers
 level: warning
 nonword: true
 tokens:
-  # Numbers with 4+ digits without commas (not years, pixels, decimals, or
-  # comma-separated values). Catches: $1540, 2875 MB, 1280 GB but not: 2023,
-  # 1920×1080, 0.0004 GB, 1.06377 GB, 1,000 GB
+  # Numbers with 4+ digits without commas (not years, pixels, or decimals).
+  # Catches: $1540, 2875 MB, 1280 GB but not: 2023, 1920×1080, 0.0004 GB,
+  # 1.06377 GB. Valid comma groups (1,000 GB) already avoid \d{4,} because
+  # they never have four consecutive digits.
   - '(?<!\d)\$\d{4,}(?!\d)'
-  - '(?<![\d.,])\d{4,}(?=\s+(?:MB|GB|TB|KB|bytes?|B)\b)'
-  - '(?<![\d.,])\d{4,}(?=\s+(?:hours?|days?|users?|files?|items?|nodes?)\b)'
+  - '(?<![\d.])\d{4,}(?=\s+(?:MB|GB|TB|KB|bytes?|B)\b)'
+  - '(?<![\d.])\d{4,}(?=\s+(?:hours?|days?|users?|files?|items?|nodes?)\b)'

--- a/styles/DigitalOcean/NumberCommas.yml
+++ b/styles/DigitalOcean/NumberCommas.yml
@@ -4,8 +4,9 @@ link: https://docs.digitalocean.com/style/digitalocean/grammar/numbers
 level: warning
 nonword: true
 tokens:
-  # Numbers with 4+ digits without commas (not years, pixels, or after decimals)
-  # Catches: $1540, 2875 MB, 1280 GB but not: 2023, 1920×1080, 1.06377
+  # Numbers with 4+ digits without commas (not years, pixels, decimals, or
+  # comma-separated values). Catches: $1540, 2875 MB, 1280 GB but not: 2023,
+  # 1920×1080, 0.0004 GB, 1.06377 GB, 1,000 GB
   - '(?<!\d)\$\d{4,}(?!\d)'
-  - '(?<!\d)\d{4,}(?=\s+(?:MB|GB|TB|KB|bytes?|B)\b)'
-  - '(?<!\d)\d{4,}(?=\s+(?:hours?|days?|users?|files?|items?|nodes?)\b)'
+  - '(?<![\d.,])\d{4,}(?=\s+(?:MB|GB|TB|KB|bytes?|B)\b)'
+  - '(?<![\d.,])\d{4,}(?=\s+(?:hours?|days?|users?|files?|items?|nodes?)\b)'


### PR DESCRIPTION
## Summary
- Fix false positives in `DigitalOcean.NumberCommas` when a decimal value has four or more digits after the point (for example `0.0004 GB`).
- Tighten the lookbehind on unit and count patterns from `(?<!\d)` to `(?<![\d.])` so digit runs inside decimals are skipped.

## Context
`content/platform/billing/bandwidth.md` uses `0.0004 GB` and `0.0002 GB`; Vale flagged `0004` and `0002` as needing commas. The rule matches `\d{4,}` (four consecutive digits). Valid `1,000 GB` never triggers that because there are only three digits after the comma; the fix does not need comma in the lookbehind. Including comma would wrongly skip malformed values like `1,0000 GB`.

## Test plan
- [ ] `0.0004 GB` does not warn; `1000 GB` still warns; `1,0000 GB` still warns.
- [ ] After release, `vale sync` in product-docs and re-run `vale content/platform/billing/bandwidth.md`.